### PR TITLE
Add meeting location and time to footer

### DIFF
--- a/content/worship/_index.md
+++ b/content/worship/_index.md
@@ -14,7 +14,7 @@ Check [the church center calendar](https://reformationparish.churchcenter.com/ca
 
 ## What to Expect
 
-Much like we refresh our bodies with food, our service is organized to renew covenant with the Lord after the patterns of worship established in Scripture. He draws us in, cleans us up, helps us see, brings us into rest with feasting, and commissions us into His purposes for us in the world. All worship is an ascent—Heaven meeting Earth—and thus, we "lift our hearts to the Lord" as we climb the hill to dine with Him.
+Much like we refresh our bodies with food, our service is organized to renew covenant with the Lord after the patterns of worship established in Scripture. He draws us in, cleans us up, renews our minds, brings us into rest with feasting, and commissions us into His purposes for us in the world. All worship is an ascent—Heaven meeting Earth—and thus, we "lift our hearts to the Lord" as we climb the hill to dine with Him.
 
 ### Call
 _The Lord Calls Us Into His Presence_\

--- a/themes/reformation/assets/css/main.css
+++ b/themes/reformation/assets/css/main.css
@@ -970,7 +970,7 @@ blockquote {
 
 .footer-inner {
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
   gap: var(--sp-16);
   padding-bottom: var(--sp-12);
 }
@@ -1013,6 +1013,15 @@ blockquote {
   gap: var(--sp-6);
 }
 
+.footer-dl__group dt {
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: 0.25em;
+  color: var(--text-muted);
+  margin-bottom: var(--sp-2);
+}
+
 .footer-dl__group dd {
   margin: 0;
 }
@@ -1026,8 +1035,8 @@ blockquote {
 }
 
 .footer-col__heading {
-  font-family: var(--font-sans);
-  font-size: 0.62rem;
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
   font-weight: 600;
   letter-spacing: 0.25em;
   text-transform: uppercase;

--- a/themes/reformation/layouts/index.html
+++ b/themes/reformation/layouts/index.html
@@ -103,6 +103,40 @@
 </section>
 
 
+<section class="section section--dark" style="padding: var(--sp-20) 0;">
+  <div class="container">
+
+    <div class="text-center" data-animate>
+      <span class="section-label">Join Us</span>
+      <h2 class="section-title">Lord's Day Worship</h2>
+      <p class="section-lead" style="margin-inline: auto; text-align: center;">
+        We welcome all who seek to worship the Triune God. Come as you are — the Table is set and the feast awaits.
+      </p>
+    </div>
+
+    <div class="service-band" data-animate>
+      <div class="service-band__item">
+        <span class="service-band__label">Day</span>
+        <span class="service-band__value">{{ with .Site.Params.serviceDay }}{{ . }}{{ else }}Sunday{{ end }}</span>
+        <span class="service-band__sub">Every week of the year</span>
+      </div>
+      <div class="service-band__item">
+        <span class="service-band__label">Time</span>
+        <span class="service-band__value">{{ with .Site.Params.serviceTime }}{{ . }}{{ else }}10:00 AM{{ end }}</span>
+        <span class="service-band__sub">Worship service</span>
+      </div>
+      <div class="service-band__item">
+        <span class="service-band__label">Location</span>
+        <span class="service-band__value">{{ with .Site.Params.meetingAddress }}{{ . | plainify | truncate 30 }}{{ end }}</span>
+        <span class="service-band__sub">
+          {{ with .Site.Params.location }}{{ . }}{{ else }}Your City, ST{{ end }}
+        </span>
+      </div>
+    </div>
+
+  </div>
+</section>
+
 <section class="section section--parchment">
   <div class="container">
 
@@ -134,41 +168,6 @@
         <p class="pillar__body">
           Our liturgy is an ordered ascent in prayer — confession, absolution, intercession, and thanksgiving — the covenant people coming before their God with one voice.
         </p>
-      </div>
-    </div>
-
-  </div>
-</section>
-
-
-<section class="section section--dark" style="padding: var(--sp-20) 0;">
-  <div class="container">
-
-    <div class="text-center" data-animate>
-      <span class="section-label">Join Us</span>
-      <h2 class="section-title">Lord's Day Worship</h2>
-      <p class="section-lead" style="margin-inline: auto; text-align: center;">
-        We welcome all who seek to worship the Triune God. Come as you are — the Table is set and the feast awaits.
-      </p>
-    </div>
-
-    <div class="service-band" data-animate>
-      <div class="service-band__item">
-        <span class="service-band__label">Day</span>
-        <span class="service-band__value">{{ with .Site.Params.serviceDay }}{{ . }}{{ else }}Sunday{{ end }}</span>
-        <span class="service-band__sub">Every week of the year</span>
-      </div>
-      <div class="service-band__item">
-        <span class="service-band__label">Time</span>
-        <span class="service-band__value">{{ with .Site.Params.serviceTime }}{{ . }}{{ else }}10:00 AM{{ end }}</span>
-        <span class="service-band__sub">Worship service</span>
-      </div>
-      <div class="service-band__item">
-        <span class="service-band__label">Location</span>
-        <span class="service-band__value">{{ with .Site.Params.meetingAddress }}{{ . | plainify | truncate 30 }}{{ end }}</span>
-        <span class="service-band__sub">
-          {{ with .Site.Params.location }}{{ . }}{{ else }}Your City, ST{{ end }}
-        </span>
       </div>
     </div>
 

--- a/themes/reformation/layouts/partials/footer.html
+++ b/themes/reformation/layouts/partials/footer.html
@@ -36,18 +36,29 @@
         </ul>
       </div>
 
+      <div class="footer-col">
+        <span class="footer-col__heading">Lord's Day</span>
+        <dl class="footer-dl">
+          <div class="footer-dl__group">
+            <dt class="footer-col__heading">Location</dt>
+            <dd>{{ .Site.Params.meetingAddress | markdownify }}<br />{{ .Site.Params.location | markdownify }}</dd>
+          </div>
+
+
+          <div class="footer-dl__group">
+            <dt class="footer-col__heading">Time</dt>
+            <dd>{{ .Site.Params.serviceDay | markdownify }}<br />{{ .Site.Params.serviceTime | markdownify }}</dd>
+          </div>
+
+        </dl>
+      </div>
+
       <!-- Contact info -->
       <div class="footer-col">
+        <span class="footer-col__heading">Contact</span>
         <div class="footer-links">
           <address class="footer-address">
             <dl class="footer-dl">
-              {{ with .Site.Params.mailingAddress }}
-              <div class="footer-dl__group">
-                <dt class="footer-col__heading">Mailing Address</dt>
-                <dd>{{ . | markdownify }}</dd>
-              </div>
-              {{ end }}
-
               {{ with .Site.Params.email }}
               <div class="footer-dl__group">
                 <dt class="footer-col__heading">Email</dt>
@@ -59,6 +70,13 @@
               <div class="footer-dl__group">
                 <dt class="footer-col__heading">Phone</dt>
                 <dd><a href="tel:{{ . }}">{{ . }}</a></dd>
+              </div>
+              {{ end }}
+
+              {{ with .Site.Params.mailingAddress }}
+              <div class="footer-dl__group">
+                <dt class="footer-col__heading">Mailing Address</dt>
+                <dd>{{ . | markdownify }}</dd>
               </div>
               {{ end }}
             </dl>


### PR DESCRIPTION
Follow on to #14 to help people who only look at footers.

For posterity, the idea behind 14 was to avoid the need to pupt it in the footer and potentially confuse contact info with worship meeting location while we don't have a permanent building. The close proximity redundancy looks a little silly (esp on desktop), but the current thinking is redundancy is better. Could potentially yeet the red worship section above the footer. 🤷 

<img width="500" alt="image" src="https://github.com/user-attachments/assets/179920de-250d-4206-b332-91a9fd7478af" />

Anna suggested moving the red section up, which looks a little better I think.